### PR TITLE
Fixed links leading to `www.ruby-lang.org/`.

### DIFF
--- a/views/installing_ruby_on_nix.haml
+++ b/views/installing_ruby_on_nix.haml
@@ -6,7 +6,7 @@
     \.
   %p 
     In order to run the koans you need Ruby installed. If you do not already have Ruby setup, please visit 
-    %a{:href => 'http://ruby-lang.org/en/downloads', :target => '_blank'} http://ruby-lang.org/en/downloads 
+    %a{:href => 'https://www.ruby-lang.org/en/downloads/', :target => '_blank'} https://www.ruby-lang.org/en/downloads/ 
     for operating system specific instructions.
   %p To verify your installation, in your terminal window simply type:
   %div.terminal

--- a/views/other_resources.haml
+++ b/views/other_resources.haml
@@ -5,9 +5,9 @@
       Edgecase Ruby Koans on Github
       %span github.com/edgecase/ruby_koans
   %p
-    %a{:href => 'http://ruby-lang.org', :target => '_blank'}
+    %a{:href => 'https://www.ruby-lang.org/', :target => '_blank'}
       The Ruby Language
-      %span ruby-lang.org
+      %span www.ruby-lang.org
   %p 
     %a{:href => 'https://ruby.github.io/TryRuby/', :target => '_blank'}
       Try Ruby in your browser


### PR DESCRIPTION
Hey!
Links leading to the Ruby language site were not working and the site did not open on them. In this pull request, they were fixed.